### PR TITLE
fix: key can't be empty message always showed

### DIFF
--- a/keytik/profile_manager/write_script.py
+++ b/keytik/profile_manager/write_script.py
@@ -456,7 +456,12 @@ class WriteDefault:
                 first_key_checkbox=row_widget.findChild(QCheckBox, RemapObject.first_key_checkbox),
                 sc_checkbox=row_widget.findChild(QCheckBox, RemapObject.scan_code_checkbox),
             )
-            remap = self.process_key_remaps(file)
+
+            if (
+                self.remap_widget.default_key_entry.text()
+                and self.remap_widget.remap_key_entry.text()
+            ):
+                remap = self.process_key_remaps(file)
 
         if condition_string:
             file.write("#HotIf\n")
@@ -468,12 +473,12 @@ class WriteDefault:
         default_key = self.remap_widget.default_key_entry.text().strip()
         remap_key = self.remap_widget.remap_key_entry.text().strip()
 
-        if not default_key:
+        if not default_key and remap_key:
             QMessageBox.warning(QApplication.activeWindow(), "Error", "Default key can't empty.")
 
             return False
 
-        if not remap_key:
+        if not remap_key and default_key:
             QMessageBox.warning(QApplication.activeWindow(), "Error", "Remap key can't empty.")
             return False
 

--- a/keytik/profile_manager/write_script.py
+++ b/keytik/profile_manager/write_script.py
@@ -457,30 +457,32 @@ class WriteDefault:
                 sc_checkbox=row_widget.findChild(QCheckBox, RemapObject.scan_code_checkbox),
             )
 
-            if (
-                self.remap_widget.default_key_entry.text()
-                and self.remap_widget.remap_key_entry.text()
-            ):
-                remap = self.process_key_remaps(file)
+            default_key = self.remap_widget.default_key_entry.text()
+            remap_key = self.remap_widget.remap_key_entry.text()
+
+            if not default_key and remap_key:
+                QMessageBox.warning(
+                    QApplication.activeWindow(), "Error", "Default key can't empty."
+                )
+
+                return False
+
+            if not remap_key and default_key:
+                QMessageBox.warning(QApplication.activeWindow(), "Error", "Remap key can't empty.")
+                return False
+
+            if remap_key and default_key:
+                self.process_key_remaps(file)
 
         if condition_string:
             file.write("#HotIf\n")
 
-        return True if remap is None else remap
+        return True
 
     def process_key_remaps(self, file):
         """Handle key remap write."""
         default_key = self.remap_widget.default_key_entry.text().strip()
         remap_key = self.remap_widget.remap_key_entry.text().strip()
-
-        if not default_key and remap_key:
-            QMessageBox.warning(QApplication.activeWindow(), "Error", "Default key can't empty.")
-
-            return False
-
-        if not remap_key and default_key:
-            QMessageBox.warning(QApplication.activeWindow(), "Error", "Remap key can't empty.")
-            return False
 
         keys = [k.strip() for k in default_key.split("+")]
         double_click_length = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,10 +89,10 @@ body = """
 {% endif %}\
 {% for group, commits in commits | group_by(attribute="group") %}
     ### {{ group | striptags | trim | upper_first }}
-    {% for commit in commits %}
+    {% for commit in commits | unique(attribute="message") %}
         - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
             {% if commit.breaking %}[**breaking**] {% endif %}\
-            {{ commit.message | upper_first }}
+            {{ commit.message | upper_first }}\
     {% endfor %}
 {% endfor %}
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ max-line-length = 100 # Match pylint default
 [tool.git-cliff.changelog]
 body = """
 {% if version %}\
-    ## KeyTik v{{ version | trim_start_matches(pat="v") }} Preview
+    ## KeyTik v{{ version | trim_start_matches(pat="v") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\
@@ -92,7 +92,7 @@ body = """
     {% for commit in commits %}
         - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
             {% if commit.breaking %}[**breaking**] {% endif %}\
-            {{ commit.message | upper_first }}\
+            {{ commit.message | upper_first }}
     {% endfor %}
 {% endfor %}
 """
@@ -108,5 +108,4 @@ commit_parsers = [
     { message = "^style", skip = true },
     { message = "^docs", skip = true },
 ]
-conventional_commits = true
-filter_unconventional = false
+skip_tags = "beta"


### PR DESCRIPTION
Checklist:

- [x] All lint checks have passed
- [x] Have run `ruff format` manually or by pre-commit before submitting PR
- [x] Have tested the modifications by running it
