### PR TITLE
chore: use constant project name on metadata

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -200,7 +200,7 @@ class Build:
 
             project = data.get("project", {})
             meta = {
-                "name": project.get("name", ""),
+                "name": "KeyTik",
                 "version": f"v{project.get('version', '')}",
             }
 


### PR DESCRIPTION
Checklist:

- [x] All lint checks have passed
- [x] Have run `ruff format` manually or by pre-commit before submitting PR
- [x] Have tested the modifications by running it
